### PR TITLE
Schema Editor: Edit Subtypes

### DIFF
--- a/src/app/schema-editor/edit-field/edit-field.component.html
+++ b/src/app/schema-editor/edit-field/edit-field.component.html
@@ -88,6 +88,7 @@
     <button class="btn btn-success bi-plus-lg ms-auto" (click)="addSubfield()">
       Add Subfield
     </button>
+    <button class="btn btn-secondary bi-clipboard-plus ms-2" (click)="pasteSubfield()" ngbTooltip="Paste Subfield"></button>
   </h2>
   <div class="list-group mb-3" cdkDropList (cdkDropListDropped)="dropSubfield($event)">
     @for (subField of field.inputList; track subField.key) {
@@ -122,9 +123,10 @@
             <input class="form-control" placeholder="Title" [(ngModel)]="subField.title" [ngbTooltip]="'The title of this subfield'"/>
           </div>
           <div class="col-auto">
-            <a class="btn btn-primary bi-pencil me-2" ngbTooltip="Edit Subfield" [routerLink]="['..', subField.key]"></a>
-            <div class="btn btn-secondary bi-grip-vertical me-2" cdkDragHandle ngbTooltip="Drag to Reorder"></div>
-            <button class="btn btn-danger bi-trash" ngbTooltip="Remove Subfield" (click)="removeSubfield($index)"></button>
+            <button class="btn m-0 p-0 btn-link text-secondary bi-clipboard me-2" ngbTooltip="Copy Subfield" (click)="copySubfield(subField)"></button>
+            <a class="btn m-0 p-0 btn-link bi-pencil me-2" ngbTooltip="Edit Subfield" [routerLink]="['..', subField.key]"></a>
+            <div class="btn m-0 p-0 btn-link text-secondary bi-grip-vertical me-2" cdkDragHandle ngbTooltip="Drag to Reorder"></div>
+            <button class="btn m-0 p-0 btn-link text-danger bi-trash" ngbTooltip="Remove Subfield" (click)="removeSubfield($index)"></button>
           </div>
         </div>
       </div>

--- a/src/app/schema-editor/edit-field/edit-field.component.html
+++ b/src/app/schema-editor/edit-field/edit-field.component.html
@@ -73,7 +73,7 @@
             <input class="form-control" [(ngModel)]="validation.message" ngbTooltip="The message to display if the validation is triggered."/>
           </div>
           <div class="col-auto">
-            <button class="btn btn-danger bi-trash" ngbTooltip="Remove Validation" (click)="removeValidation($index)"></button>
+            <button class="btn m-0 p-0 btn-link text-danger bi-trash" ngbTooltip="Remove Validation" (click)="removeValidation($index)"></button>
           </div>
         </div>
       </div>

--- a/src/app/schema-editor/edit-schema/edit-schema.component.html
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.html
@@ -11,9 +11,12 @@
       Preview
     </h5>
     <app-form [typeSchema]="schemaSections" [formData]="{data: {}}" [editable]="true" (deleted)="deleteSection($event)"></app-form>
-    <button class="btn btn-success bi-plus-lg mt-3" (click)="addSection()">
-      Add Section
-    </button>
+    <div class="mt-3">
+      <button class="btn btn-success bi-plus-lg me-2" (click)="addSection()">
+        Add Section
+      </button>
+      <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Section" (click)="pasteSection()"></button>
+    </div>
   </div>
   <div default class="h-100 d-flex justify-content-center align-items-center flex-column">
     <h2>

--- a/src/app/schema-editor/edit-schema/edit-schema.component.html
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.html
@@ -3,6 +3,9 @@
     <h4>
       <a class="bi-chevron-left" routerLink="../.."></a>
       Edit Schema: {{ title }}
+      @if (equipmentType) {
+        <button class="btn btn-link bi-pencil" ngbTooltip="Rename" (click)="renameSubType()"></button>
+      }
     </h4>
     <h5>
       Preview

--- a/src/app/schema-editor/edit-schema/edit-schema.component.ts
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.ts
@@ -92,6 +92,7 @@ export class EditSchemaComponent implements OnInit, SaveableChangesComponent {
   addSection() {
     this.schemaService.createSchemaSection(this.kind, {
       id: 0,
+      typeId: this.route.snapshot.params.id,
       name: 'New Section',
       schema: [],
     }).subscribe(({data}) => {

--- a/src/app/schema-editor/edit-schema/edit-schema.component.ts
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.ts
@@ -1,11 +1,13 @@
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, RouterLink} from '@angular/router';
+import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 import {EMPTY, switchMap} from 'rxjs';
 
 import {MasterDetailComponent} from '../../shared/components/master-detail/master-detail.component';
 import {FormComponent} from '../../shared/form/form/form.component';
 import {SaveableChangesComponent} from '../../shared/guard/unsaved-changes.guard';
 import {icons} from '../../shared/icons';
+import {EquipmentType} from '../../shared/model/equipment.interface';
 import {SchemaSection} from '../../shared/model/schema.interface';
 import {Breadcrumb, BreadcrumbService} from '../../shared/services/breadcrumb.service';
 import {EquipmentService} from '../../shared/services/equipment.service';
@@ -21,15 +23,17 @@ import {SchemaContextService} from '../schema-context.service';
     MasterDetailComponent,
     RouterLink,
     FormComponent,
+    NgbTooltip,
   ],
 })
 export class EditSchemaComponent implements OnInit, SaveableChangesComponent {
   kind: SchemaKind = 'preAudit';
   title = '';
   schemaSections: SchemaSection[] = [];
+  equipmentType?: EquipmentType;
 
   constructor(
-    private route: ActivatedRoute,
+    protected route: ActivatedRoute,
     private schemaService: SchemaService,
     private equipmentService: EquipmentService,
     private schemaContext: SchemaContextService,
@@ -72,6 +76,7 @@ export class EditSchemaComponent implements OnInit, SaveableChangesComponent {
             this.title = breadcrumb.label = 'Equipment';
             // Category ID does not seem to matter, we just pass 0
             this.equipmentService.getEquipmentType(0, id).subscribe(({data}) => {
+              this.equipmentType = data;
               this.title = breadcrumb.label = data.name;
             });
             break;
@@ -107,6 +112,21 @@ export class EditSchemaComponent implements OnInit, SaveableChangesComponent {
 
     this.schemaService.deleteSchemaSection(this.kind, section.id).subscribe(() => {
       this.schemaSections.splice(this.schemaSections.indexOf(section), 1);
+    });
+  }
+
+  renameSubType() {
+    const newName = prompt('Enter a new name for this equipment type:', this.title);
+    if (!newName) {
+      return;
+    }
+
+    this.equipmentService.updateEquipmentType(0, {
+      id: this.equipmentType!.id,
+      equipmentId: this.equipmentType!.equipmentId,
+      name: newName,
+    }).subscribe(() => {
+      this.title = newName;
     });
   }
 }

--- a/src/app/schema-editor/edit-schema/edit-schema.component.ts
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.ts
@@ -57,7 +57,7 @@ export class EditSchemaComponent implements OnInit, SaveableChangesComponent {
         switch (kind) {
           case 'preaudit':
             this.kind = 'preAudit';
-            this.title = breadcrumb.label = 'Preaudit';
+            this.title = breadcrumb.label = 'Pre-Audit';
             break;
           case 'grants':
             this.kind = 'grants';

--- a/src/app/schema-editor/edit-schema/edit-schema.component.ts
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.ts
@@ -97,10 +97,15 @@ export class EditSchemaComponent implements OnInit, SaveableChangesComponent {
   }
 
   addSection() {
+    const name = prompt('Enter a name for the new section:');
+    if (!name) {
+      return;
+    }
+
     this.schemaService.createSchemaSection(this.kind, {
       id: 0,
       typeId: this.route.snapshot.params.id,
-      name: 'New Section',
+      name,
       schema: [],
     }).subscribe(({data}) => {
       this.schemaSections.push(data);

--- a/src/app/schema-editor/edit-section/edit-section.component.html
+++ b/src/app/schema-editor/edit-section/edit-section.component.html
@@ -76,6 +76,7 @@
     <button class="btn btn-success bi-plus-lg ms-auto" (click)="addCopySpec()">
       Add Copy Button
     </button>
+    <button class="btn btn-secondary bi-clipboard-plus ms-2" (click)="pasteCopySpec()" ngbTooltip="Paste Copy Button"></button>
   </h2>
   <div class="list-group mb-3">
     @for (copySpec of section.copySchema; track copySpec) {
@@ -98,7 +99,8 @@
             })">
               Edit Field Mapping
             </button>
-            <button class="btn btn-danger bi-trash" (click)="deleteCopySpec($index)" ngbTooltip="Remove"></button>
+            <button class="btn m-0 p-0 btn-link text-secondary bi-clipboard me-2" (click)="copyCopySpec(copySpec)" ngbTooltip="Copy"></button>
+            <button class="btn m-0 p-0 btn-link text-danger bi-trash" (click)="deleteCopySpec($index)" ngbTooltip="Remove"></button>
           </div>
         </div>
       </div>

--- a/src/app/schema-editor/edit-section/edit-section.component.html
+++ b/src/app/schema-editor/edit-section/edit-section.component.html
@@ -61,7 +61,7 @@
             <input class="form-control" [(ngModel)]="condition.message" ngbTooltip="The message to display if the condition is triggered." (change)="setDirty()"/>
           </div>
           <div class="col-auto">
-            <button class="btn btn-danger bi-trash" ngbTooltip="Remove Condition" (click)="removeCondition($index)"></button>
+            <button class="btn m-0 p-0 btn-link text-danger bi-trash" ngbTooltip="Remove Condition" (click)="removeCondition($index)"></button>
           </div>
         </div>
       </div>
@@ -122,7 +122,7 @@
     <button type="button" class="btn-close" aria-label="Close" (click)="editSpec = undefined; offcanvas.dismiss()"></button>
   </div>
   <div class="offcanvas-body pt-0">
-    <table class="table">
+    <table class="table align-middle">
       <thead class="sticky-top">
       <tr>
         <th>Source</th>
@@ -130,17 +130,17 @@
         <th>Target</th>
         <th></th>
       </tr>
-      <tr>
+      <tr class="align-middle">
         <td class="p-0 font-monospace">
           <input type="text" class="form-control" placeholder="Source Field" [(ngModel)]="newSource" [ngbTypeahead]="search">
         </td>
-        <td class="text-center align-middle">
+        <td class="text-center">
           <i class="bi-arrow-right"></i>
         </td>
         <td class="p-0 font-monospace">
           <input type="text" class="form-control" placeholder="Target Field" [(ngModel)]="newTarget" [ngbTypeahead]="search">
         </td>
-        <td class="p-0">
+        <td>
           <button
             class="btn btn-sm btn-success bi-plus-lg"
             ngbTooltip="Add Mapping"
@@ -156,15 +156,15 @@
             <td class="font-monospace">
               {{ field.value }}
             </td>
-            <td class="text-center align-middle">
+            <td class="text-center">
               <i class="bi-arrow-right"></i>
             </td>
             <td class="font-monospace">
               {{ field.key }}
             </td>
-            <td class="p-0">
+            <td class="text-center">
               <button
-                class="btn btn-sm btn-danger bi-trash"
+                class="btn m-0 p-0 btn-link text-danger bi-trash"
                 ngbTooltip="Remove Mapping"
                 (click)="deleteMapping(field.key)"
               ></button>

--- a/src/app/schema-editor/edit-section/edit-section.component.ts
+++ b/src/app/schema-editor/edit-section/edit-section.component.ts
@@ -7,7 +7,7 @@ import {NgbOffcanvas, NgbPopover, NgbTooltip, NgbTypeahead} from '@ng-bootstrap/
 import {combineLatestWith, debounceTime, distinctUntilChanged, map, Observable, OperatorFunction} from 'rxjs';
 
 import {icons} from '../../shared/icons';
-import {CopySpec, DisabledSchema, SchemaSection} from '../../shared/model/schema.interface';
+import {CopySpec, SchemaSection} from '../../shared/model/schema.interface';
 import {ExpressionErrorPipe} from '../../shared/pipe/expression-error.pipe';
 import {Breadcrumb, BreadcrumbService} from '../../shared/services/breadcrumb.service';
 import {CopyPasteService} from '../../shared/services/copy-paste.service';

--- a/src/app/schema-editor/edit-section/edit-section.component.ts
+++ b/src/app/schema-editor/edit-section/edit-section.component.ts
@@ -2,13 +2,15 @@ import {KeyValuePipe} from '@angular/common';
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ActivatedRoute} from '@angular/router';
+import {ToastService} from '@mean-stream/ngbx';
 import {NgbOffcanvas, NgbPopover, NgbTooltip, NgbTypeahead} from '@ng-bootstrap/ng-bootstrap';
 import {combineLatestWith, debounceTime, distinctUntilChanged, map, Observable, OperatorFunction} from 'rxjs';
 
 import {icons} from '../../shared/icons';
-import {CopySpec, SchemaSection} from '../../shared/model/schema.interface';
+import {CopySpec, DisabledSchema, SchemaSection} from '../../shared/model/schema.interface';
 import {ExpressionErrorPipe} from '../../shared/pipe/expression-error.pipe';
 import {Breadcrumb, BreadcrumbService} from '../../shared/services/breadcrumb.service';
+import {CopyPasteService} from '../../shared/services/copy-paste.service';
 import {SchemaContextService} from '../schema-context.service';
 
 @Component({
@@ -47,6 +49,8 @@ export class EditSectionComponent implements OnInit, OnDestroy {
     private schemaContext: SchemaContextService,
     private breadcrumbService: BreadcrumbService,
     protected ngbOffcanvas: NgbOffcanvas,
+    private copyPasteService: CopyPasteService,
+    private toastService: ToastService,
   ) {
   }
 
@@ -93,6 +97,26 @@ export class EditSectionComponent implements OnInit, OnDestroy {
   deleteCopySpec($index: number) {
     this.section.copySchema?.splice($index, 1);
     this.setDirty();
+  }
+
+  copyCopySpec(spec: CopySpec) {
+    this.copyPasteService.copy(spec).subscribe(() => {
+      this.toastService.success('Copied to Clipboard', 'Button and mappings copied to clipboard');
+    });
+  }
+
+  pasteCopySpec() {
+    this.copyPasteService.paste<CopySpec>([
+      'buttonLabel',
+      'mappingInputs',
+    ]).subscribe({
+      next: spec => {
+        this.section.copySchema?.push(spec);
+        this.setDirty();
+        this.toastService.success('Pasted Copy Spec', 'Successfully pasted button and mappings');
+      },
+      error: error => this.toastService.error('Failed to Paste Copy Spec', 'Clipboard is empty or does not contain a valid copy spec', error),
+    });
   }
 
   addMapping(source: string, target: string) {

--- a/src/app/schema-editor/select-schema/select-schema.component.html
+++ b/src/app/schema-editor/select-schema/select-schema.component.html
@@ -60,6 +60,7 @@
                 <li>
                   <a [routerLink]="['equipment', equipmentType.id]">{{ equipmentType.name }}</a>
                   <button class="btn m-0 p-0 btn-link text-secondary bi-copy ms-2" ngbTooltip="Duplicate Subtype" (click)="duplicateSubType(equipmentType)"></button>
+                  <button class="btn m-0 p-0 btn-link text-danger bi-trash ms-2" ngbTooltip="Delete Subtype" (click)="deleteSubType(equipmentType)"></button>
                 </li>
               }
             </ul>

--- a/src/app/schema-editor/select-schema/select-schema.component.html
+++ b/src/app/schema-editor/select-schema/select-schema.component.html
@@ -42,6 +42,9 @@
           <h5>
             {{ category.equipmentName }}
           </h5>
+          <button class="btn btn-link btn-sm text-secondary bi-plus-lg" (click)="$event.preventDefault(); $event.stopImmediatePropagation(); addSubType(category)">
+            Add Subtype
+          </button>
         </a>
       } @else {
         <div class="list-group-item">
@@ -61,6 +64,9 @@
                 </li>
               }
             </ul>
+            <button class="btn btn-link btn-sm text-secondary bi-plus-lg" (click)="addSubType(category)">
+              Add Subtype
+            </button>
           </details>
         </div>
       }

--- a/src/app/schema-editor/select-schema/select-schema.component.html
+++ b/src/app/schema-editor/select-schema/select-schema.component.html
@@ -42,7 +42,7 @@
           <h5>
             {{ category.equipmentName }}
           </h5>
-          <button class="btn btn-link btn-sm text-secondary bi-plus-lg" (click)="$event.preventDefault(); $event.stopImmediatePropagation(); addSubType(category)">
+          <button class="btn btn-sm btn-outline-secondary bi-plus-lg" (click)="$event.preventDefault(); $event.stopImmediatePropagation(); addSubType(category)">
             Add Subtype
           </button>
         </a>
@@ -64,7 +64,7 @@
                 </li>
               }
             </ul>
-            <button class="btn btn-link btn-sm text-secondary bi-plus-lg" (click)="addSubType(category)">
+            <button class="btn btn-outline-secondary btn-sm bi-plus-lg" (click)="addSubType(category)">
               Add Subtype
             </button>
           </details>

--- a/src/app/schema-editor/select-schema/select-schema.component.html
+++ b/src/app/schema-editor/select-schema/select-schema.component.html
@@ -8,7 +8,7 @@
   <div class="list-group mb-3">
     <a class="list-group-item list-group-item-action" routerLink="preaudit/0">
       <h5 class="bi-file-earmark-text">
-        Pre Audit
+        Pre-Audit
       </h5>
       Basic information about the audit.
     </a>

--- a/src/app/schema-editor/select-schema/select-schema.component.html
+++ b/src/app/schema-editor/select-schema/select-schema.component.html
@@ -58,9 +58,8 @@
             <ul>
               @for (equipmentType of equipments; track equipmentType.id) {
                 <li>
-                  <a [routerLink]="['equipment', equipmentType.id]">
-                    {{ equipmentType.name }}
-                  </a>
+                  <a [routerLink]="['equipment', equipmentType.id]">{{ equipmentType.name }}</a>
+                  <button class="btn m-0 p-0 btn-link text-secondary bi-copy ms-2" ngbTooltip="Duplicate Subtype" (click)="duplicateSubType(equipmentType)"></button>
                 </li>
               }
             </ul>

--- a/src/app/schema-editor/select-schema/select-schema.component.ts
+++ b/src/app/schema-editor/select-schema/select-schema.component.ts
@@ -1,15 +1,19 @@
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, RouterLink} from '@angular/router';
+import {ToastService} from '@mean-stream/ngbx';
+import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
+import {concatMap, mergeMap, switchMap, tap, toArray} from 'rxjs';
 
 import {EquipmentCategory, EquipmentType} from '../../shared/model/equipment.interface';
 import {BreadcrumbService} from '../../shared/services/breadcrumb.service';
 import {EquipmentService} from '../../shared/services/equipment.service';
+import {SchemaService} from '../../shared/services/schema.service';
 
 @Component({
   selector: 'app-select-schema',
   templateUrl: './select-schema.component.html',
   styleUrl: './select-schema.component.scss',
-  imports: [RouterLink],
+  imports: [RouterLink, NgbTooltip],
 })
 export class SelectSchemaComponent implements OnInit {
   categories: EquipmentCategory[] = [];
@@ -19,6 +23,8 @@ export class SelectSchemaComponent implements OnInit {
     private equipmentService: EquipmentService,
     private breadcrumbService: BreadcrumbService,
     private route: ActivatedRoute,
+    private schemaService: SchemaService,
+    private toastService: ToastService,
   ) {
   }
 
@@ -48,6 +54,34 @@ export class SelectSchemaComponent implements OnInit {
       name,
     }).subscribe(({data}) => {
       this.equipmentTypes[category.id]?.push(data);
+    });
+  }
+
+  duplicateSubType(subType: EquipmentType) {
+    const name = prompt('Enter the name of the new type', subType.name);
+    if (!name) {
+      return;
+    }
+
+    this.equipmentService.createEquipmentType(subType.equipmentId, {
+      equipmentId: subType.equipmentId,
+      name,
+    }).pipe(
+      tap(({data}) => this.equipmentTypes[subType.equipmentId]?.push(data)),
+      switchMap(newSubType => this.schemaService.getSchema(`equipment/${subType.id}`).pipe(
+        mergeMap(({data}) => data),
+        concatMap(schema => this.schemaService.createSchemaSection(`equipment/${subType.equipmentId}`, {
+          ...schema,
+          id: 0,
+          typeId: newSubType.data.id,
+        })),
+        toArray(),
+      )),
+    ).subscribe(result => {
+      this.toastService.success(
+        'Duplicated Subtype',
+        `Successfully duplicated subtype ${subType.name} and ${result.length} schema sections`,
+      );
     });
   }
 }

--- a/src/app/schema-editor/select-schema/select-schema.component.ts
+++ b/src/app/schema-editor/select-schema/select-schema.component.ts
@@ -36,4 +36,21 @@ export class SelectSchemaComponent implements OnInit {
       }
     });
   }
+
+  addSubType(category: EquipmentCategory) {
+    const name = prompt('Enter the name of the new type');
+    if (!name) {
+      return;
+    }
+
+    this.equipmentService.createEquipmentType(category.id, {
+      id: 0,
+      equipmentId: category.id,
+      equipment: category,
+      name,
+      deleteStatus: false,
+    }).subscribe(({data}) => {
+      this.equipmentTypes[category.id]?.push(data);
+    });
+  }
 }

--- a/src/app/schema-editor/select-schema/select-schema.component.ts
+++ b/src/app/schema-editor/select-schema/select-schema.component.ts
@@ -44,11 +44,8 @@ export class SelectSchemaComponent implements OnInit {
     }
 
     this.equipmentService.createEquipmentType(category.id, {
-      id: 0,
       equipmentId: category.id,
-      equipment: category,
       name,
-      deleteStatus: false,
     }).subscribe(({data}) => {
       this.equipmentTypes[category.id]?.push(data);
     });

--- a/src/app/schema-editor/select-schema/select-schema.component.ts
+++ b/src/app/schema-editor/select-schema/select-schema.component.ts
@@ -84,4 +84,15 @@ export class SelectSchemaComponent implements OnInit {
       );
     });
   }
+
+  deleteSubType(subType: EquipmentType) {
+    if (!confirm('Are you sure you want to delete this subtype? This action cannot be undone.')) {
+      return;
+    }
+
+    this.equipmentService.deleteEquipmentType(subType.equipmentId, subType.id).subscribe(() => {
+      this.equipmentTypes[subType.equipmentId]!.splice(this.equipmentTypes[subType.equipmentId]!.indexOf(subType), 1);
+      this.toastService.warn('Deleted Subtype', `Successfully deleted subtype ${subType.name}`);
+    })
+  }
 }

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -17,6 +17,11 @@
             @if (schema._dirty) {
               <span class="text-warning me-2" ngbTooltip="Modified. Don't forget to save.">*</span>
             }
+            <button
+              class="btn btn-sm btn-secondary bi-clipboard me-2"
+              ngbTooltip="Copy Section"
+              (click)="copySection(schema); $event.stopPropagation()"
+            ></button>
             <a
               class="btn btn-sm btn-primary bi-pencil me-2"
               ngbTooltip="Edit Section"

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -7,6 +7,9 @@
         <button ngbAccordionButton [disabled]="!editable && disabled">
           <div class="flex-grow-1">
             {{ schema.name }}
+            @if (editable && schema._dirty) {
+              <span class="text-warning me-2" ngbTooltip="Modified. Don't forget to save.">*</span>
+            }
           </div>
           @if (disabled) {
             <div class="text-muted me-3">
@@ -14,22 +17,19 @@
             </div>
           }
           @if (editable) {
-            @if (schema._dirty) {
-              <span class="text-warning me-2" ngbTooltip="Modified. Don't forget to save.">*</span>
-            }
             <button
-              class="btn btn-sm btn-secondary bi-clipboard me-2"
+              class="btn m-0 p-0 btn-link text-secondary bi-clipboard me-2"
               ngbTooltip="Copy Section"
               (click)="copySection(schema); $event.stopPropagation()"
             ></button>
             <a
-              class="btn btn-sm btn-primary bi-pencil me-2"
+              class="btn m-0 p-0 btn-link bi-pencil me-2"
               ngbTooltip="Edit Section"
               [routerLink]="['section', schema.id]" [state]="{section: schema}"
               (click)="$event.stopPropagation()"
             ></a>
             <button
-              class="btn btn-sm btn-danger bi-trash me-2"
+              class="btn m-0 p-0 btn-link text-danger bi-trash me-2"
               ngbTooltip="Remove Section"
               [disabled]="!accordion.collapsed"
               (click)="deleted.next(schema); $event.stopPropagation()"
@@ -59,24 +59,24 @@
                                       (dirty)="setDirty()"></app-form-element>
                   }
                   @if (editable) {
-                    <div class="position-absolute top-0 end-0">
+                    <div class="position-absolute top-0 end-0 rounded border bg-blur">
                       <button
-                        class="btn btn-sm btn-secondary bi-clipboard me-2"
+                        class="btn m-0 p-1 btn-link text-secondary bi-clipboard"
                         ngbTooltip="Copy Field"
                         (click)="copyField(element); $event.stopPropagation()"
                       ></button>
                       <a
-                        class="btn btn-sm btn-primary bi-pencil me-2"
+                        class="btn m-0 p-1 btn-link bi-pencil"
                         ngbTooltip="Edit Field"
                         [routerLink]="['field', element.key]"
                       ></a>
                       <div
-                        class="btn btn-sm btn-secondary bi-grip-vertical me-2"
+                        class="btn m-0 p-1 btn-link text-secondary bi-grip-vertical"
                         ngbTooltip="Drag to Reorder"
                         cdkDragHandle
                       ></div>
                       <button
-                        class="btn btn-sm btn-danger bi-trash me-2"
+                        class="btn m-0 p-1 btn-link text-danger bi-trash"
                         ngbTooltip="Remove Field"
                         (click)="removeFormElement(schema, $index)"
                       ></button>

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -60,6 +60,11 @@
                   }
                   @if (editable) {
                     <div class="position-absolute top-0 end-0">
+                      <button
+                        class="btn btn-sm btn-secondary bi-clipboard me-2"
+                        ngbTooltip="Copy Field"
+                        (click)="copyField(element); $event.stopPropagation()"
+                      ></button>
                       <a
                         class="btn btn-sm btn-primary bi-pencil me-2"
                         ngbTooltip="Edit Field"
@@ -81,9 +86,10 @@
               }
             </div>
             @if (editable) {
-              <button class="btn btn-success bi-plus-lg" (click)="addFormElement(schema)">
+              <button class="btn btn-success bi-plus-lg me-2" (click)="addFormElement(schema)">
                 Add Field
               </button>
+              <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Field" (click)="pasteField(schema)"></button>
             }
           </ng-template>
         </div>

--- a/src/app/shared/form/form/form.component.ts
+++ b/src/app/shared/form/form/form.component.ts
@@ -186,4 +186,11 @@ export class FormComponent implements OnInit, SaveableChangesComponent {
     section.schema.splice($index, 1);
     section._dirty = true;
   }
+
+  copySection(schema: SchemaSection) {
+    const string = JSON.stringify({...schema, id: undefined, _dirty: undefined});
+    navigator.clipboard.writeText(string).then(() => {
+      this.toastService.success('Copied', `Section ${schema.name} copied to clipboard`);
+    });
+  }
 }

--- a/src/app/shared/form/form/form.component.ts
+++ b/src/app/shared/form/form/form.component.ts
@@ -193,4 +193,25 @@ export class FormComponent implements OnInit, SaveableChangesComponent {
       this.toastService.success('Copied', `Section ${schema.name} copied to clipboard`);
     });
   }
+
+  copyField(element: SchemaElement) {
+    const string = JSON.stringify(element);
+    navigator.clipboard.writeText(string).then(() => {
+      this.toastService.success('Copied', `Field ${element.key} copied to clipboard`);
+    });
+  }
+
+  pasteField(section: SchemaSection) {
+    navigator.clipboard.readText().then(text => {
+      const element = JSON.parse(text);
+      if (!element.key || !element.dataType || !element.type || !element.title) {
+        throw new Error('Invalid Section');
+      }
+      section.schema.push(element);
+      section._dirty = true;
+      this.toastService.success('Pasted Section', `Successfully pasted section ${element.name}`);
+    }).catch(error => {
+      this.toastService.error('Failed to Paste Section', 'Clipboard is empty or does not contain a valid section', error);
+    });
+  }
 }

--- a/src/app/shared/model/equipment.interface.ts
+++ b/src/app/shared/model/equipment.interface.ts
@@ -23,6 +23,8 @@ export interface EquipmentType {
   equipmentId: number;
   equipment: EquipmentCategory;
 }
+export type CreateEquipmentTypeDto = Pick<EquipmentType, 'name' | 'equipmentId'>;
+export type UpdateEquipmentTypeDto = Pick<EquipmentType, 'id' | 'name' | 'equipmentId'>;
 
 /**
  * A category of equipment, e.g. "Refrigeration" or "Lighting".

--- a/src/app/shared/model/schema.interface.ts
+++ b/src/app/shared/model/schema.interface.ts
@@ -1,5 +1,6 @@
 export interface SchemaSection {
   id: number;
+  typeId?: number;
   name: string;
   schema: SchemaElement[];
   copySchema?: CopySpec[];

--- a/src/app/shared/services/copy-paste.service.ts
+++ b/src/app/shared/services/copy-paste.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@angular/core";
+import {map, Observable} from 'rxjs';
+import {fromPromise} from 'rxjs/internal/observable/innerFrom';
+
+@Injectable({providedIn: 'root'})
+export class CopyPasteService {
+
+  copy<T>(element: T, erasedKeys?: (keyof T)[]) {
+    if (erasedKeys) {
+      element = {...element};
+      for (const key of erasedKeys) {
+        delete element[key];
+      }
+    }
+
+    const string = JSON.stringify(element);
+    return fromPromise(navigator.clipboard.writeText(string));
+  }
+
+  paste<T>(requiredKeys: (keyof T)[]): Observable<T> {
+    return fromPromise(navigator.clipboard.readText()).pipe(
+      map(text => {
+        const element = JSON.parse(text);
+        const missingKey = requiredKeys.find(k => element[k] === undefined);
+        if (missingKey) {
+          throw new Error(`Missing key: ${missingKey.toString()}`);
+        }
+        return element;
+      }),
+    );
+  }
+}

--- a/src/app/shared/services/equipment.service.ts
+++ b/src/app/shared/services/equipment.service.ts
@@ -37,6 +37,10 @@ export class EquipmentService {
     return this.http.get<Response<EquipmentType[]>>(`${environment.url}api/equipment/${categoryId}/type`);
   }
 
+  createEquipmentType(categoryId: number, data: EquipmentType): Observable<Response<EquipmentType>> {
+    return this.http.post<Response<EquipmentType>>(`${environment.url}api/equipment/${categoryId}/type`, data);
+  }
+
   getEquipment(zoneId: number, categoryId: number, id: number): Observable<Response<Equipment>> {
     return this.http.get<Response<Equipment>>(`${environment.url}api/zone/${zoneId}/equipment/${categoryId}/subType/${id}`);
   }

--- a/src/app/shared/services/equipment.service.ts
+++ b/src/app/shared/services/equipment.service.ts
@@ -4,11 +4,11 @@ import {Observable} from 'rxjs';
 import {environment} from 'src/environments/environment.prod';
 import {
   CreateEquipmentDto,
-  CreateEquipmentFormData,
+  CreateEquipmentFormData, CreateEquipmentTypeDto,
   Equipment,
   EquipmentCategory,
   EquipmentFormData,
-  EquipmentType,
+  EquipmentType, UpdateEquipmentTypeDto,
 } from '../model/equipment.interface';
 import {HvacConnectedZone, ZoneWithHvacConnected} from '../model/zone.interface';
 import {Response} from '../model/response.interface';
@@ -37,8 +37,16 @@ export class EquipmentService {
     return this.http.get<Response<EquipmentType[]>>(`${environment.url}api/equipment/${categoryId}/type`);
   }
 
-  createEquipmentType(categoryId: number, data: EquipmentType): Observable<Response<EquipmentType>> {
+  createEquipmentType(categoryId: number, data: CreateEquipmentTypeDto): Observable<Response<EquipmentType>> {
     return this.http.post<Response<EquipmentType>>(`${environment.url}api/equipment/${categoryId}/type`, data);
+  }
+
+  updateEquipmentType(categoryId: number, data: UpdateEquipmentTypeDto): Observable<Response<EquipmentType>> {
+    return this.http.put<Response<EquipmentType>>(`${environment.url}api/equipment/${categoryId}/type/${data.id}`, data);
+  }
+
+  deleteEquipmentType(categoryId: number, id: number): Observable<Response> {
+    return this.http.delete<Response>(`${environment.url}api/equipment/${categoryId}/type/${id}`);
   }
 
   getEquipment(zoneId: number, categoryId: number, id: number): Observable<Response<Equipment>> {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -79,6 +79,11 @@ ul.pagination, ol.breadcrumb {
   margin-bottom: 0;
 }
 
+.bg-blur {
+  background-color: rgba(127, 127, 127, 0.25);
+  backdrop-filter: blur(10px);
+}
+
 .icon-conserve::before {
   display: inline-block;
   font-style: normal;


### PR DESCRIPTION
- Added buttons to create new subtypes and duplicate existing subtypes.
- Added a way to rename subtypes.
- Added a way to delete subtypes.
- Improved schema editor visuals.
- Added copy and paste for schema sections and fields.