### PR TITLE
Duplicate Equipment: Select Zone, Custom Name, and Fixed Endpoint

### DIFF
--- a/src/app/audit/add-data-collector-modal/add-data-collector-modal.component.html
+++ b/src/app/audit/add-data-collector-modal/add-data-collector-modal.component.html
@@ -4,6 +4,7 @@
     <span class="text-muted">{{ audit?.auditName | titlecase }}</span>
   </ng-container>
   <ng-container modal-body>
+    <!-- TODO add search field -->
     <ul class="list-unstyled">
       @for (item of dataCollectors; track item.id) {
         <li>

--- a/src/app/equipment/connect-zone/connect-zone.component.html
+++ b/src/app/equipment/connect-zone/connect-zone.component.html
@@ -6,6 +6,7 @@
     <p>
       Select the zones you want to connect to this HVAC unit.
     </p>
+    <!-- TODO add search field -->
     @for (zone of connectedZones; track zone.zoneId) {
       <div class="form-check">
         <input class="form-check-input" type="checkbox" id="zone-{{ zone.zoneId }}" [(ngModel)]="selection[zone.zoneId]">

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
@@ -1,0 +1,35 @@
+<ngbx-modal [back]="['..']" #modal>
+  <ng-container modal-title>
+    Duplicate
+  </ng-container>
+  <ng-container modal-body>
+    <div class="mb-3">
+      <label for="new-name" class="form-label">
+        New Name
+      </label>
+      <input type="text" id="new-name" class="form-control" [placeholder]="toDuplicate?.name" [(ngModel)]="newName" />
+      <div class="form-text">
+        Enter a new name for the duplicated equipment.
+        If left empty, the original name will be used.
+      </div>
+    </div>
+    <div class="mb-3">
+      <label for="zone" class="form-label">
+        Zone
+        <span class="text-danger" ngbTooltip="Required">*</span>
+      </label>
+      <select class="form-select" id="zone" [(ngModel)]="zone">
+        @for (zone of zones; track zone.zoneId) {
+          <option [value]="zone.zoneId">{{ zone.zoneName }}</option>
+        }
+      </select>
+      <div class="form-text">
+        Select the zone where the equipment will be duplicated.
+      </div>
+    </div>
+  </ng-container>
+  <ng-container modal-footer>
+    <button type="button" class="btn btn-secondary" (click)="modal.close()">Cancel</button>
+    <button type="button" class="btn btn-primary" (click)="duplicate(); modal.close()">Duplicate</button>
+  </ng-container>
+</ngbx-modal>

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
@@ -18,8 +18,9 @@
         Zones
         <span class="text-danger" ngbTooltip="Required">*</span>
       </label>
+      <input type="search" class="form-control mb-3" [(ngModel)]="zoneSearch" placeholder="Search zones..." />
       <div class="p-3 rounded border" style="max-height: 300px; overflow-y: auto;">
-        @for (zone of zones; track zone.zoneId) {
+        @for (zone of zones | search:zoneSearch:['zoneName']; track zone.zoneId) {
           <div class="form-check">
             <input
               class="form-check-input"

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
@@ -43,7 +43,7 @@
   <ng-container modal-footer>
     <button type="button" class="btn btn-secondary" (click)="modal.close()">Cancel</button>
     <button type="button" class="btn btn-primary" (click)="duplicate()" [disabled]="!selectedZones.size">
-      Duplicate {{ selectedZones.size }}x
+      Duplicate {{ selectedZones.size }}&times;
     </button>
   </ng-container>
 </ngbx-modal>

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
@@ -1,6 +1,6 @@
 <ngbx-modal [back]="['..']" #modal>
   <ng-container modal-title>
-    Duplicate
+    Duplicate {{ toDuplicate?.type?.name }}
   </ng-container>
   <ng-container modal-body>
     <div class="mb-3">
@@ -15,21 +15,34 @@
     </div>
     <div class="mb-3">
       <label for="zone" class="form-label">
-        Zone
+        Zones
         <span class="text-danger" ngbTooltip="Required">*</span>
       </label>
-      <select class="form-select" id="zone" [(ngModel)]="zone">
+      <div class="p-3 rounded border" style="max-height: 300px; overflow-y: auto;">
         @for (zone of zones; track zone.zoneId) {
-          <option [value]="zone.zoneId">{{ zone.zoneName }}</option>
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="check-{{ zone.zoneId }}"
+              [ngModel]="selectedZones.has(zone.zoneId)"
+              (ngModelChange)="$event ? selectedZones.add(zone.zoneId) : selectedZones.delete(zone.zoneId)"
+            />
+            <label class="form-check-label" for="check-{{ zone.zoneId }}">
+              {{ zone.zoneName }}
+            </label>
+          </div>
         }
-      </select>
+      </div>
       <div class="form-text">
-        Select the zone where the equipment will be duplicated.
+        Select all the zones where the equipment will be duplicated.
       </div>
     </div>
   </ng-container>
   <ng-container modal-footer>
     <button type="button" class="btn btn-secondary" (click)="modal.close()">Cancel</button>
-    <button type="button" class="btn btn-primary" (click)="duplicate(); modal.close()">Duplicate</button>
+    <button type="button" class="btn btn-primary" (click)="duplicate(); modal.close()" [disabled]="!selectedZones.size">
+      Duplicate {{ selectedZones.size }}x
+    </button>
   </ng-container>
 </ngbx-modal>

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.html
@@ -41,7 +41,7 @@
   </ng-container>
   <ng-container modal-footer>
     <button type="button" class="btn btn-secondary" (click)="modal.close()">Cancel</button>
-    <button type="button" class="btn btn-primary" (click)="duplicate(); modal.close()" [disabled]="!selectedZones.size">
+    <button type="button" class="btn btn-primary" (click)="duplicate()" [disabled]="!selectedZones.size">
       Duplicate {{ selectedZones.size }}x
     </button>
   </ng-container>

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.spec.ts
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DuplicateEquipmentModalComponent } from './duplicate-equipment-modal.component';
+
+describe('DuplicateEquipmentModalComponent', () => {
+  let component: DuplicateEquipmentModalComponent;
+  let fixture: ComponentFixture<DuplicateEquipmentModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DuplicateEquipmentModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DuplicateEquipmentModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
@@ -1,0 +1,70 @@
+import {Component, OnInit} from '@angular/core';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {ActivatedRoute} from '@angular/router';
+import {ModalModule, ToastService} from '@mean-stream/ngbx';
+import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
+import {switchMap} from 'rxjs';
+import {Equipment} from '../../shared/model/equipment.interface';
+import {Zone} from '../../shared/model/zone.interface';
+import {AuditZoneService} from '../../shared/services/audit-zone.service';
+import {EquipmentService} from '../../shared/services/equipment.service';
+
+@Component({
+  selector: 'app-duplicate-equipment-modal',
+  templateUrl: './duplicate-equipment-modal.component.html',
+  styleUrl: './duplicate-equipment-modal.component.scss',
+  imports: [
+    ModalModule,
+    NgbTooltip,
+    ReactiveFormsModule,
+    FormsModule,
+  ],
+})
+export class DuplicateEquipmentModalComponent implements OnInit {
+  zones: Zone[] = [];
+
+  toDuplicate?: Equipment;
+  newName = '';
+  zone?: Zone;
+
+  constructor(
+    private route: ActivatedRoute,
+    private equipmentService: EquipmentService,
+    private zoneService: AuditZoneService,
+    private toastService: ToastService,
+  ) {
+  }
+
+  ngOnInit() {
+    this.route.params.pipe(
+      switchMap(({aid}) => this.zoneService.getAllAuditZone(aid)),
+    ).subscribe(res => {
+      this.zones = res.data;
+    });
+
+    this.route.params.pipe(
+      switchMap(({zid, eid, tid}) => this.equipmentService.getEquipment(zid, eid, tid)),
+    ).subscribe(res => {
+      this.toDuplicate = res.data;
+    });
+  }
+
+  duplicate() {
+    const item = this.toDuplicate;
+    if (!item) {
+      return;
+    }
+
+    const kind = item.type?.name;
+    const zoneId = this.zone?.zoneId ?? item.zoneId;
+    this.equipmentService.duplicateEquipment(item.id, zoneId, this.newName).subscribe(({data}) => {
+      const toast = this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind}`);
+      if (zoneId === item.zoneId) {
+        toast.actions = [{
+          name: 'Show',
+          link: [`/audits/${item.auditId}/zones/${zoneId}/equipments/${item.equipmentId}/types/${data.id}`],
+        }];
+      }
+    });
+  }
+}

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
@@ -25,7 +25,7 @@ export class DuplicateEquipmentModalComponent implements OnInit {
 
   toDuplicate?: Equipment;
   newName = '';
-  zone?: Zone;
+  selectedZones = new Set<number>;
 
   constructor(
     private route: ActivatedRoute,
@@ -56,15 +56,15 @@ export class DuplicateEquipmentModalComponent implements OnInit {
     }
 
     const kind = item.type?.name;
-    const zoneId = this.zone?.zoneId ?? item.zoneId;
-    this.equipmentService.duplicateEquipment(item.id, zoneId, this.newName).subscribe(({data}) => {
-      const toast = this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind}`);
-      if (zoneId === item.zoneId) {
+    for (const zoneId of this.selectedZones) {
+      this.equipmentService.duplicateEquipment(item.id, zoneId, this.newName).subscribe(({data}) => {
+        const zone = this.zones.find(z => z.zoneId === zoneId);
+        const toast = this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind} to zone ${zone?.zoneName ?? ''}`);
         toast.actions = [{
           name: 'Show',
           link: [`/audits/${item.auditId}/zones/${zoneId}/equipments/${item.equipmentId}/types/${data.id}`],
         }];
-      }
-    });
+      });
+    }
   }
 }

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
@@ -6,6 +6,7 @@ import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 import {switchMap} from 'rxjs';
 import {Equipment} from '../../shared/model/equipment.interface';
 import {Zone} from '../../shared/model/zone.interface';
+import {SearchPipe} from '../../shared/pipe/search.pipe';
 import {AuditZoneService} from '../../shared/services/audit-zone.service';
 import {EquipmentService} from '../../shared/services/equipment.service';
 
@@ -18,6 +19,7 @@ import {EquipmentService} from '../../shared/services/equipment.service';
     NgbTooltip,
     ReactiveFormsModule,
     FormsModule,
+    SearchPipe,
   ],
 })
 export class DuplicateEquipmentModalComponent implements OnInit {
@@ -25,6 +27,7 @@ export class DuplicateEquipmentModalComponent implements OnInit {
 
   toDuplicate?: Equipment;
   newName = '';
+  zoneSearch = '';
   selectedZones = new Set<number>;
 
   constructor(

--- a/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
+++ b/src/app/equipment/duplicate-equipment-modal/duplicate-equipment-modal.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {ModalModule, ToastService} from '@mean-stream/ngbx';
 import {NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 import {switchMap} from 'rxjs';
@@ -29,6 +29,7 @@ export class DuplicateEquipmentModalComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private equipmentService: EquipmentService,
     private zoneService: AuditZoneService,
     private toastService: ToastService,
@@ -64,6 +65,10 @@ export class DuplicateEquipmentModalComponent implements OnInit {
           name: 'Show',
           link: [`/audits/${item.auditId}/zones/${zoneId}/equipments/${item.equipmentId}/types/${data.id}`],
         }];
+
+        if (zoneId === item.zoneId) {
+          this.router.navigate(['..'], {relativeTo: this.route, queryParams: {new: data.id}});
+        }
       });
     }
   }

--- a/src/app/equipment/equipment-detail/equipment-detail.component.html
+++ b/src/app/equipment/equipment-detail/equipment-detail.component.html
@@ -1,5 +1,9 @@
 <ng-template #options>
-  <app-equipment-options-dropdown [equipment]="equipment"></app-equipment-options-dropdown>
+  <app-equipment-options-dropdown [equipment]="equipment">
+    <a ngbDropdownItem class="bi-copy" routerLink="duplicate">
+      Duplicate to...
+    </a>
+  </app-equipment-options-dropdown>
 </ng-template>
 <div class="bg-dark text-light mb-3 p-3">
   <h1>

--- a/src/app/equipment/equipment-detail/equipment-detail.component.ts
+++ b/src/app/equipment/equipment-detail/equipment-detail.component.ts
@@ -2,6 +2,7 @@ import {TitleCasePipe} from '@angular/common';
 import {AfterViewInit, Component, OnDestroy, OnInit, TemplateRef, ViewChild} from '@angular/core';
 import {ActivatedRoute, RouterLink, RouterOutlet} from '@angular/router';
 import {ToastService} from '@mean-stream/ngbx';
+import {NgbDropdownItem} from '@ng-bootstrap/ng-bootstrap';
 import {map, switchMap, tap} from 'rxjs';
 
 import {ListPlaceholderComponent} from '../../shared/components/list-placeholder/list-placeholder.component';
@@ -33,6 +34,7 @@ import {EquipmentOptionsDropdownComponent} from '../equipment-options-dropdown/e
     TitleCasePipe,
     EquipmentOptionsDropdownComponent,
     ListPlaceholderComponent,
+    NgbDropdownItem,
   ],
 })
 export class EquipmentDetailComponent implements OnInit, OnDestroy, AfterViewInit, SaveableChangesComponent {

--- a/src/app/equipment/equipment-list/equipment-list.component.html
+++ b/src/app/equipment/equipment-list/equipment-list.component.html
@@ -42,7 +42,10 @@
 
 <ng-template #duplicateModal let-modal>
   <div class="modal-header">
-    <h4 class="modal-title" id="modal-basic-title">Duplicate</h4>
+    <h4 class="modal-title" id="modal-basic-title">
+      Duplicate
+      {{ toDuplicate?.type?.name }}
+    </h4>
     <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
   </div>
   <div class="modal-body">
@@ -51,16 +54,24 @@
         New Name
       </label>
       <input type="text" id="new-name" class="form-control" #newName [placeholder]="toDuplicate?.name">
+      <div class="form-text">
+        Enter a new name for the duplicated equipment.
+        If left empty, the original name will be used.
+      </div>
     </div>
     <div class="mb-3">
       <label for="zone" class="form-label">
         Zone
+        <span class="text-danger" ngbTooltip="Required">*</span>
       </label>
       <select class="form-select" id="zone" #zoneSelect>
         @for (zone of zones; track zone.zoneId) {
           <option [value]="zone.zoneId">{{ zone.zoneName }}</option>
         }
       </select>
+      <div class="form-text">
+        Select the zone where the equipment will be duplicated.
+      </div>
     </div>
   </div>
   <div class="modal-footer">

--- a/src/app/equipment/equipment-list/equipment-list.component.html
+++ b/src/app/equipment/equipment-list/equipment-list.component.html
@@ -21,9 +21,9 @@
           <button ngbDropdownItem class="bi-copy" (click)="duplicate(item)">
             Duplicate
           </button>
-          <button ngbDropdownItem class="bi-copy" (click)="toDuplicate = item; loadZones(); modal.open(duplicateModal)">
+          <a ngbDropdownItem class="bi-copy" [routerLink]="['types', item.id, 'duplicate']">
             Duplicate to...
-          </button>
+          </a>
           <div class="dropdown-divider"></div>
           <button ngbDropdownItem class="bi-trash text-danger" (click)="delete(item)">
             Delete
@@ -39,43 +39,3 @@
 } @else {
   <app-list-placeholder></app-list-placeholder>
 }
-
-<ng-template #duplicateModal let-modal>
-  <div class="modal-header">
-    <h4 class="modal-title" id="modal-basic-title">
-      Duplicate
-      {{ toDuplicate?.type?.name }}
-    </h4>
-    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
-  </div>
-  <div class="modal-body">
-    <div class="mb-3">
-      <label for="new-name" class="form-label">
-        New Name
-      </label>
-      <input type="text" id="new-name" class="form-control" #newName [placeholder]="toDuplicate?.name">
-      <div class="form-text">
-        Enter a new name for the duplicated equipment.
-        If left empty, the original name will be used.
-      </div>
-    </div>
-    <div class="mb-3">
-      <label for="zone" class="form-label">
-        Zone
-        <span class="text-danger" ngbTooltip="Required">*</span>
-      </label>
-      <select class="form-select" id="zone" #zoneSelect>
-        @for (zone of zones; track zone.zoneId) {
-          <option [value]="zone.zoneId">{{ zone.zoneName }}</option>
-        }
-      </select>
-      <div class="form-text">
-        Select the zone where the equipment will be duplicated.
-      </div>
-    </div>
-  </div>
-  <div class="modal-footer">
-    <button type="button" class="btn btn-secondary" (click)="modal.dismiss()">Cancel</button>
-    <button type="button" class="btn btn-primary" (click)="duplicate(toDuplicate!, +zoneSelect.value, newName.value); modal.close()">Duplicate</button>
-  </div>
-</ng-template>

--- a/src/app/equipment/equipment-list/equipment-list.component.html
+++ b/src/app/equipment/equipment-list/equipment-list.component.html
@@ -21,6 +21,9 @@
           <button ngbDropdownItem class="bi-copy" (click)="duplicate(item)">
             Duplicate
           </button>
+          <button ngbDropdownItem class="bi-copy" (click)="toDuplicate = item; loadZones(); modal.open(duplicateModal)">
+            Duplicate to...
+          </button>
           <div class="dropdown-divider"></div>
           <button ngbDropdownItem class="bi-trash text-danger" (click)="delete(item)">
             Delete
@@ -36,3 +39,32 @@
 } @else {
   <app-list-placeholder></app-list-placeholder>
 }
+
+<ng-template #duplicateModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title" id="modal-basic-title">Duplicate</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
+  </div>
+  <div class="modal-body">
+    <div class="mb-3">
+      <label for="new-name" class="form-label">
+        New Name
+      </label>
+      <input type="text" id="new-name" class="form-control" #newName [placeholder]="toDuplicate?.name">
+    </div>
+    <div class="mb-3">
+      <label for="zone" class="form-label">
+        Zone
+      </label>
+      <select class="form-select" id="zone" #zoneSelect>
+        @for (zone of zones; track zone.zoneId) {
+          <option [value]="zone.zoneId">{{ zone.zoneName }}</option>
+        }
+      </select>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="modal.dismiss()">Cancel</button>
+    <button type="button" class="btn btn-primary" (click)="duplicate(toDuplicate!, +zoneSelect.value, newName.value); modal.close()">Duplicate</button>
+  </div>
+</ng-template>

--- a/src/app/equipment/equipment-list/equipment-list.component.ts
+++ b/src/app/equipment/equipment-list/equipment-list.component.ts
@@ -122,18 +122,11 @@ export class EquipmentListComponent implements OnInit {
     });
   }
 
-  duplicate(item: Equipment, zoneId = item.zoneId, name?: string) {
+  duplicate(item: Equipment) {
     const kind = item.type?.name;
-    this.equipmentService.duplicateEquipment(item.id, zoneId, name).subscribe(({data}) => {
-      const toast = this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind}`);
-      if (zoneId === item.zoneId) {
-        this.equipments!.push(data);
-      } else {
-        toast.actions = [{
-          name: 'Show',
-          link: [`/audits/${item.auditId}/zones/${zoneId}/equipments/${item.equipmentId}/types/${data.id}`],
-        }];
-      }
+    this.equipmentService.duplicateEquipment(item.id, item.zoneId).subscribe(({data}) => {
+      this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind}`);
+      this.equipments!.push(data);
     });
   }
 }

--- a/src/app/equipment/equipment-list/equipment-list.component.ts
+++ b/src/app/equipment/equipment-list/equipment-list.component.ts
@@ -3,7 +3,7 @@ import {Component, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ActivatedRoute, Router, RouterLink, RouterLinkActive} from '@angular/router';
 import {ToastService} from '@mean-stream/ngbx';
-import {NgbDropdownButtonItem, NgbDropdownItem, NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {NgbDropdownButtonItem, NgbDropdownItem, NgbModal, NgbTooltip} from '@ng-bootstrap/ng-bootstrap';
 import {EMPTY, switchMap} from 'rxjs';
 
 import {FeatureCardComponent} from '../../shared/components/feature-card/feature-card.component';
@@ -31,7 +31,7 @@ import {EquipmentOptionsDropdownComponent} from '../equipment-options-dropdown/e
     FormsModule,
     SearchPipe,
     RouterLinkActive,
-
+    NgbTooltip,
   ],
 })
 export class EquipmentListComponent implements OnInit {
@@ -125,8 +125,15 @@ export class EquipmentListComponent implements OnInit {
   duplicate(item: Equipment, zoneId = item.zoneId, name?: string) {
     const kind = item.type?.name;
     this.equipmentService.duplicateEquipment(item.id, zoneId, name).subscribe(({data}) => {
-      this.equipments!.push(data);
-      this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind}`);
+      const toast = this.toastService.success('Duplicate Equipment', `Successfully duplicated ${kind}`);
+      if (zoneId === item.zoneId) {
+        this.equipments!.push(data);
+      } else {
+        toast.actions = [{
+          name: 'Show',
+          link: [`/audits/${item.auditId}/zones/${zoneId}/equipments/${item.equipmentId}/types/${data.id}`],
+        }];
+      }
     });
   }
 }

--- a/src/app/equipment/equipment.routes.ts
+++ b/src/app/equipment/equipment.routes.ts
@@ -1,4 +1,5 @@
 import {Routes} from '@angular/router';
+import {DuplicateEquipmentModalComponent} from './duplicate-equipment-modal/duplicate-equipment-modal.component';
 import {EquipmentMasterDetailComponent} from './equipment-master-detail/equipment-master-detail.component';
 import {CreateEquipmentComponent} from './create-equipment/create-equipment.component';
 import {EquipmentDetailComponent} from './equipment-detail/equipment-detail.component';
@@ -21,6 +22,7 @@ export const routes: Routes = [
         canDeactivate: [UnsavedChangesGuard],
         children: [
           {path: 'connect', component: ConnectZoneComponent},
+          {path: 'duplicate', component: DuplicateEquipmentModalComponent},
         ],
       },
     ],

--- a/src/app/shared/services/audit-zone.service.ts
+++ b/src/app/shared/services/audit-zone.service.ts
@@ -30,9 +30,8 @@ export class AuditZoneService {
     return this.http.put<Response<Zone>>(`${environment.url}api/audit/${auditId}/zone/${zoneId}`, data);
   }
 
-  duplicateAuditZone(zoneId: number, count: number): Observable<Response<Zone[]>> {
-    return this.http.post<Response<Zone[]>>(`${environment.url}api/zone/duplicate`, {
-      zoneId,
+  duplicateAuditZone(auditId: number, zoneId: number, count: number): Observable<Response<Zone[]>> {
+    return this.http.post<Response<Zone[]>>(`${environment.url}api/audit/${auditId}/zone/${zoneId}/duplicate`, {
       countDuplicate: count,
     });
   }

--- a/src/app/shared/services/equipment.service.ts
+++ b/src/app/shared/services/equipment.service.ts
@@ -69,10 +69,11 @@ export class EquipmentService {
     return this.http.delete<Response>(`${environment.url}api/zone/${zoneId}/equipment/${categoryId}/subType/${id}`);
   }
 
-  duplicateEquipment(zoneId: number, id: number): Observable<Response<Equipment>> {
-    return this.http.post<Response<Equipment>>(`${environment.url}api/equipment/form/duplicate`, {
+  duplicateEquipment(id: number, zoneId: number, name?: string): Observable<Response<Equipment>> {
+    return this.http.post<Response<Equipment>>(`${environment.url}api/formData/equipment/subType/${id}/duplicate`, {
       zoneId,
       subTypeId: id,
+      name,
     });
   }
 

--- a/src/app/zone/zone-list/zone-list.component.ts
+++ b/src/app/zone/zone-list/zone-list.component.ts
@@ -78,7 +78,7 @@ export class ZoneListComponent implements OnInit {
     if (!count || isNaN(+count)) {
       return;
     }
-    this.zoneService.duplicateAuditZone(zone.zoneId, +count).subscribe(response => {
+    this.zoneService.duplicateAuditZone(zone.auditId, zone.zoneId, +count).subscribe(response => {
       this.zones!.push(...response.data);
       this.toastService.success('Duplicate Zone', 'Successfully duplicated zone.');
     });


### PR DESCRIPTION
- Added a new equipment option "Duplicate to..." which opens a modal.
  - The new equipment can have a custom name instead of "<old name> 1"
  - The new equipment can be placed in one or more zones

# Screenshots

![image](https://github.com/user-attachments/assets/1a4f913d-c83d-4a6c-9889-37ad23d8a7ce)

