### PR TITLE
Schema Field Units

### DIFF
--- a/src/app/schema-editor/edit-field/edit-field.component.ts
+++ b/src/app/schema-editor/edit-field/edit-field.component.ts
@@ -156,6 +156,15 @@ export class EditFieldComponent implements OnInit, OnDestroy {
                 },
               ],
             },
+            {
+              dependentKeyValue: ['number', 'integer'],
+              key: 'unit',
+              dataType: 'text',
+              type: 'textBox',
+              title: 'Physical Unit',
+              hint: 'The physical unit of the input field',
+              required: false,
+            },
             // --------------- Date ---------------
             {
               dependentKeyValue: 'date',

--- a/src/app/shared/form/form-element/form-element.component.html
+++ b/src/app/shared/form/form-element/form-element.component.html
@@ -92,17 +92,25 @@
   }
   @default {
     @let type = element.dataType === 'integer' ? 'number' : element.dataType;
-    <input
-      [type]="type"
-      [step]="element.dataType === 'integer' ? 1 : null"
-      class="form-control"
-      [id]="id"
-      [(ngModel)]="formData.data[element.key]"
-      (change)="setDirty()"
-      [attr.aria-describedby]="id + '-help'"
-      [disabled]="!!element.disabled"
-      [placeholder]="element.defaultValue ?? ''"
-    >
+    <div class="input-group">
+      @if (element.unit && (element.unit | isCurrency)) {
+        <span class="input-group-text">{{ element.unit }}</span>
+      }
+      <input
+        [type]="type"
+        [step]="element.dataType === 'integer' ? 1 : null"
+        class="form-control"
+        [id]="id"
+        [(ngModel)]="formData.data[element.key]"
+        (change)="setDirty()"
+        [attr.aria-describedby]="id + '-help'"
+        [disabled]="!!element.disabled"
+        [placeholder]="element.defaultValue ?? ''"
+      >
+      @if (element.unit && !(element.unit | isCurrency)) {
+        <span class="input-group-text">{{ element.unit }}</span>
+      }
+    </div>
   }
 }
 @if (element.type !== 'checkbox' && element.hint) {

--- a/src/app/shared/form/form-element/form-element.component.ts
+++ b/src/app/shared/form/form-element/form-element.component.ts
@@ -8,6 +8,7 @@ import {
   SchemaSubElement,
   SchemaValue,
 } from '../../model/schema.interface';
+import {IsCurrencyPipe} from '../../pipe/is-currency.pipe';
 import {ExpressionService} from '../../services/expression.service';
 import {FormChoicesPipe} from '../form-choices.pipe';
 
@@ -19,6 +20,7 @@ import {FormChoicesPipe} from '../form-choices.pipe';
     NgbTooltip,
     FormsModule,
     FormChoicesPipe,
+    IsCurrencyPipe,
   ],
 })
 export class FormElementComponent implements OnInit, OnChanges {

--- a/src/app/shared/model/schema.interface.ts
+++ b/src/app/shared/model/schema.interface.ts
@@ -49,6 +49,7 @@ export interface SchemaElement {
   heading?: string;
   required?: boolean;
   disabled?: boolean;
+  unit?: string;
   defaultValue?: SchemaValue;
   gridSize?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 

--- a/src/app/shared/pipe/is-currency.pipe.ts
+++ b/src/app/shared/pipe/is-currency.pipe.ts
@@ -1,0 +1,15 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+const CURRENCY_SYMBOLS = new Set([
+  '$', '€', '£', '¥', '₹', '₩', '₽', '₺', '₪', '₫', '₱', '₦', '₴', '₭',
+  'EUR', 'USD', 'GBP', 'JPY', 'INR', 'KRW', 'RUB', 'TRY', 'ILS', 'VND', 'PHP', 'NGN', 'UAH', 'LAK',
+]);
+
+@Pipe({
+  name: 'isCurrency',
+})
+export class IsCurrencyPipe implements PipeTransform {
+  transform(value: string): boolean {
+    return CURRENCY_SYMBOLS.has(value);
+  }
+}


### PR DESCRIPTION
- Adds an option for number or integer fields to have a unit or currency.
- Units are displayed after the input field.
- Currencies are displayed before the input field.

Note: only `textBox` inputs display the unit. `select` and `radio` do not.

![image](https://github.com/user-attachments/assets/85080edf-6e6f-43ab-b868-d3f121d1a0a1)
![image](https://github.com/user-attachments/assets/8b4a3706-60c8-4b19-8550-ff01c431e54c)
