### PR TITLE
Reorder schema sections

### DIFF
--- a/src/app/schema-editor/edit-field/edit-field.component.html
+++ b/src/app/schema-editor/edit-field/edit-field.component.html
@@ -10,13 +10,13 @@
     Summary
   </h2>
   <div class="mb-3">
-    <app-editor [(ngModel)]="field.summary" (ngModelChange)="setDirty()"></app-editor>
+    <app-editor [ngModel]="field.summary" (ngModelChange)="setDocs('summary', $event)"></app-editor>
   </div>
   <h2>
     Documentation
   </h2>
   <div class="mb-3">
-    <app-editor [(ngModel)]="field.docs" (ngModelChange)="setDirty()"></app-editor>
+    <app-editor [ngModel]="field.docs" (ngModelChange)="setDocs('docs', $event)"></app-editor>
   </div>
   <h2 class="d-flex align-items-center">
     Validation

--- a/src/app/schema-editor/edit-field/edit-field.component.ts
+++ b/src/app/schema-editor/edit-field/edit-field.component.ts
@@ -321,6 +321,16 @@ export class EditFieldComponent implements OnInit, OnDestroy {
     this.section!._dirty = dirty;
   }
 
+  setDocs(key: 'summary' | 'docs', value: string) {
+    if (value === '<p></p>') {
+      value = '';
+    }
+    if (this.field[key] !== value) {
+      this.field[key] = value;
+      this.setDirty();
+    }
+  }
+
   addValidation() {
     (this.field.validations ??= []).push({
       level: 'warning',

--- a/src/app/schema-editor/edit-schema/edit-schema.component.html
+++ b/src/app/schema-editor/edit-schema/edit-schema.component.html
@@ -15,6 +15,9 @@
         Add Section
       </button>
       <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Section" (click)="pasteSection()"></button>
+      <button class="btn btn-primary me-2" (click)="saveAll()">
+        Save All
+      </button>
     </div>
   </div>
   <div default class="h-100 d-flex justify-content-center align-items-center flex-column">

--- a/src/app/schema-editor/edit-section/edit-section.component.html
+++ b/src/app/schema-editor/edit-section/edit-section.component.html
@@ -10,11 +10,11 @@
   </div>
   <h2>Summary</h2>
   <div class="mb-3">
-    <app-editor [(ngModel)]="section.summary" (ngModelChange)="setDirty()"></app-editor>
+    <app-editor [ngModel]="section.summary" (ngModelChange)="setDocs('summary', $event)"></app-editor>
   </div>
   <h2>Documentation</h2>
   <div class="mb-3">
-    <app-editor [(ngModel)]="section.docs" (ngModelChange)="setDirty()"></app-editor>
+    <app-editor [ngModel]="section.docs" (ngModelChange)="setDocs('docs', $event)"></app-editor>
   </div>
   <h2 class="d-flex align-items-center">
     Conditional Rules

--- a/src/app/schema-editor/edit-section/edit-section.component.ts
+++ b/src/app/schema-editor/edit-section/edit-section.component.ts
@@ -130,4 +130,14 @@ export class EditSectionComponent implements OnInit, OnDestroy {
     delete this.editSpec!.mappingInputs[key];
     this.setDirty();
   }
+
+  setDocs(key: 'summary' | 'docs', value: string) {
+    if (value === '<p></p>') {
+      value = '';
+    }
+    if (this.section[key] !== value) {
+      this.section[key] = value;
+      this.setDirty();
+    }
+  }
 }

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -49,12 +49,19 @@
               [routerLink]="['section', schema.id]" [state]="{section: schema}"
               (click)="$event.stopPropagation()"
             ></a>
-            <div class="btn m-0 p-0 btn-link text-secondary bi-grip-vertical me-2" ngbTooltip="Drag to Reorder"
-                 cdkDragHandle></div>
+            @let collapsed = accordion.collapsed;
+            <div
+              class="btn m-0 p-0 btn-link text-secondary bi-grip-vertical me-2"
+              [class.disabled]="!collapsed"
+              ngbTooltip="Drag to Reorder"
+              [disableTooltip]="!collapsed"
+              cdkDragHandle
+              [cdkDragHandleDisabled]="!collapsed"
+            ></div>
             <button
               class="btn m-0 p-0 btn-link text-danger bi-trash me-2"
               ngbTooltip="Remove Section"
-              [disabled]="!accordion.collapsed"
+              [disabled]="!collapsed"
               (click)="deleted.next(schema); $event.stopPropagation()"
             ></button>
           } @else {

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -22,8 +22,7 @@
           <div class="flex-grow-1">
             {{ schema.name }}
             @if (schema.summary || schema.docs) {
-              <app-help-icon [title]="schema.name" [summary]="schema.summary" [docs]="schema.docs"
-                             (click)="$event.stopPropagation()"></app-help-icon>
+              <app-help-icon [title]="schema.name" [summary]="schema.summary" [docs]="schema.docs" (click)="$event.stopPropagation()"></app-help-icon>
             }
             @if (search && elements.length) {
               <span class="text-muted me-2">({{ elements.length }})</span>
@@ -65,8 +64,7 @@
               (click)="deleted.next(schema); $event.stopPropagation()"
             ></button>
           } @else {
-            <app-progress-bar class="w-25" [status]="false"
-                              [progress]="progressPerSection[schema.id]"></app-progress-bar>
+            <app-progress-bar class="w-25" [status]="false" [progress]="progressPerSection[schema.id]"></app-progress-bar>
           }
         </button>
       </h2>
@@ -132,8 +130,7 @@
               <button class="btn btn-success bi-plus-lg me-2" (click)="addFormElement(schema)">
                 Add Field
               </button>
-              <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Field"
-                      (click)="pasteField(schema)"></button>
+              <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Field" (click)="pasteField(schema)"></button>
             }
           </ng-template>
         </div>

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -4,7 +4,7 @@
   placeholder="Search form fields"
   [(ngModel)]="search"
 />
-<div ngbAccordion [closeOthers]="true" cdkDropList>
+<div ngbAccordion [closeOthers]="true" cdkDropList [cdkDropListDisabled]="!editable">
   @for (schema of typeSchema; track schema.id) {
     @let elements = schema.schema | search:search:['key', 'title'];
     <div

--- a/src/app/shared/form/form/form.component.html
+++ b/src/app/shared/form/form/form.component.html
@@ -4,10 +4,17 @@
   placeholder="Search form fields"
   [(ngModel)]="search"
 />
-<div ngbAccordion [closeOthers]="true">
+<div ngbAccordion [closeOthers]="true" cdkDropList>
   @for (schema of typeSchema; track schema.id) {
     @let elements = schema.schema | search:search:['key', 'title'];
-    <div ngbAccordionItem #accordion=ngbAccordionItem [id]="'s-' + schema.id" [title]="schema.name">
+    <div
+      ngbAccordionItem
+      #accordion=ngbAccordionItem
+      [id]="'s-' + schema.id"
+      [title]="schema.name"
+      cdkDrag
+      (cdkDragDropped)="dropSection($event)"
+    >
       <h2 ngbAccordionHeader>
         @let condition = schema.conditionalSchema?.disabled?.[0]?.['if'];
         @let disabled = condition && (condition | eval:formData.data | async);
@@ -15,7 +22,8 @@
           <div class="flex-grow-1">
             {{ schema.name }}
             @if (schema.summary || schema.docs) {
-              <app-help-icon [title]="schema.name" [summary]="schema.summary" [docs]="schema.docs" (click)="$event.stopPropagation()"></app-help-icon>
+              <app-help-icon [title]="schema.name" [summary]="schema.summary" [docs]="schema.docs"
+                             (click)="$event.stopPropagation()"></app-help-icon>
             }
             @if (search && elements.length) {
               <span class="text-muted me-2">({{ elements.length }})</span>
@@ -41,6 +49,8 @@
               [routerLink]="['section', schema.id]" [state]="{section: schema}"
               (click)="$event.stopPropagation()"
             ></a>
+            <div class="btn m-0 p-0 btn-link text-secondary bi-grip-vertical me-2" ngbTooltip="Drag to Reorder"
+                 cdkDragHandle></div>
             <button
               class="btn m-0 p-0 btn-link text-danger bi-trash me-2"
               ngbTooltip="Remove Section"
@@ -48,7 +58,8 @@
               (click)="deleted.next(schema); $event.stopPropagation()"
             ></button>
           } @else {
-            <app-progress-bar class="w-25" [status]="false" [progress]="progressPerSection[schema.id]"></app-progress-bar>
+            <app-progress-bar class="w-25" [status]="false"
+                              [progress]="progressPerSection[schema.id]"></app-progress-bar>
           }
         </button>
       </h2>
@@ -114,7 +125,8 @@
               <button class="btn btn-success bi-plus-lg me-2" (click)="addFormElement(schema)">
                 Add Field
               </button>
-              <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Field" (click)="pasteField(schema)"></button>
+              <button class="btn btn-secondary bi-clipboard-plus me-2" ngbTooltip="Paste Field"
+                      (click)="pasteField(schema)"></button>
             }
           </ng-template>
         </div>

--- a/src/app/shared/form/form/form.component.ts
+++ b/src/app/shared/form/form/form.component.ts
@@ -205,6 +205,17 @@ export class FormComponent implements OnInit, SaveableChangesComponent {
     section._dirty = true;
   }
 
+  dropSection(event: CdkDragDrop<SchemaSection[]>) {
+    moveItemInArray(this.typeSchema, event.previousIndex, event.currentIndex);
+    for (let i = 0; i < this.typeSchema.length; i++) {
+      const section = this.typeSchema[i];
+      if (section.order !== i) {
+        section.order = i;
+        section._dirty = true;
+      }
+    }
+  }
+
   addFormElement(section: SchemaSection) {
     section.schema.push({
       key: `new_${section.schema.length + 1}`,

--- a/src/app/shared/model/schema.interface.ts
+++ b/src/app/shared/model/schema.interface.ts
@@ -2,6 +2,7 @@ export interface SchemaSection {
   id: number;
   typeId?: number;
   name: string;
+  order?: number;
   summary?: string;
   docs?: string;
   schema: SchemaElement[];

--- a/src/app/shared/services/schema.service.ts
+++ b/src/app/shared/services/schema.service.ts
@@ -1,9 +1,9 @@
-import {Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
-import {SchemaSection} from '../model/schema.interface';
-import {environment} from '../../../environments/environment.prod';
 import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {Observable, tap} from 'rxjs';
+import {environment} from '../../../environments/environment.prod';
 import {Response} from '../model/response.interface';
+import {SchemaSection} from '../model/schema.interface';
 
 export type SchemaKind = 'preAudit' | 'ceh' | 'grants' | 'zone' | `equipment/${number}`;
 
@@ -15,7 +15,10 @@ export class SchemaService {
   }
 
   getSchema(kind: SchemaKind): Observable<Response<SchemaSection[]>> {
-    return this.http.get<Response<SchemaSection[]>>(`${environment.url}api/schemas/${kind}`);
+    return this.http.get<Response<SchemaSection[]>>(`${environment.url}api/schemas/${kind}`).pipe(
+      // TODO remove this when backend does the sorting
+      tap(res => res.data.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))),
+    );
   }
 
   createSchemaSection(kind: SchemaKind, data: SchemaSection): Observable<Response<SchemaSection>> {


### PR DESCRIPTION
- Added a way to reorder schema sections based on the new `order` attribute.
- Added a button to save all modified schema sections.
- After erasing docs/summary of a section/field, the help icon will now be hidden.

<img width="800" height="1428" alt="image" src="https://github.com/user-attachments/assets/95e7bd1c-b9e1-4f5f-9d48-aad824f58579" />
